### PR TITLE
Fix Redis multiplexer ownership

### DIFF
--- a/src/Redis/Orleans.Clustering.Redis/Hosting/RedisClusteringProviderBuilder.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Hosting/RedisClusteringProviderBuilder.cs
@@ -30,7 +30,7 @@ internal sealed class RedisClusteringProviderBuilder : IProviderBuilder<ISiloBui
                 {
                     // Get a connection multiplexer instance by name.
                     var multiplexer = services.GetRequiredKeyedService<IConnectionMultiplexer>(serviceKey);
-                    options.CreateMultiplexer = _ => Task.FromResult(multiplexer);
+                    options.CreateMultiplexer = _ => Task.FromResult((Multiplexer: multiplexer, IsShared: true));
                     options.ConfigurationOptions = new ConfigurationOptions();
                 }
                 else
@@ -63,7 +63,7 @@ internal sealed class RedisClusteringProviderBuilder : IProviderBuilder<ISiloBui
                 {
                     // Get a connection multiplexer instance by name.
                     var multiplexer = services.GetRequiredKeyedService<IConnectionMultiplexer>(serviceKey);
-                    options.CreateMultiplexer = _ => Task.FromResult(multiplexer);
+                    options.CreateMultiplexer = _ => Task.FromResult((Multiplexer: multiplexer, IsShared: true));
                     options.ConfigurationOptions = new ConfigurationOptions();
                 }
                 else

--- a/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
@@ -20,9 +20,12 @@ namespace Orleans.Clustering.Redis
         public ConfigurationOptions ConfigurationOptions { get; set; }
 
         /// <summary>
-        /// The delegate used to create a Redis connection multiplexer.
+        /// The delegate used to create a Redis connection multiplexer and indicate whether it is shared.
         /// </summary>
-        public Func<RedisClusteringOptions, Task<IConnectionMultiplexer>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
+        /// <remarks>
+        /// When <c>IsShared</c> is <see langword="true"/>, the provider will not dispose the returned multiplexer.
+        /// </remarks>
+        public Func<RedisClusteringOptions, Task<(IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
 
         /// <summary>
         /// The delegate used to create redis key for RedisMembershipTable.
@@ -38,9 +41,9 @@ namespace Orleans.Clustering.Redis
         /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
-        public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisClusteringOptions options)
+        public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisClusteringOptions options)
         {
-            return await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions);
+            return (await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions), false);
         }
 
         /// <summary>

--- a/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
@@ -22,6 +22,7 @@ namespace Orleans.Clustering.Redis
         private readonly RedisKey _clusterKey;
         private IConnectionMultiplexer _muxer = null!;
         private IDatabase _db = null!;
+        private bool _muxerIsShared;
 
         public RedisMembershipTable(IOptions<RedisClusteringOptions> redisOptions, IOptions<ClusterOptions> clusterOptions)
         {
@@ -40,7 +41,7 @@ namespace Orleans.Clustering.Redis
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
         {
-            _muxer = await _redisOptions.CreateMultiplexer(_redisOptions);
+            (_muxer, _muxerIsShared) = await _redisOptions.CreateMultiplexer(_redisOptions);
             _db = _muxer.GetDatabase();
 
             if (tryInitTableVersion)
@@ -216,7 +217,14 @@ namespace Orleans.Clustering.Redis
 
         public void Dispose()
         {
-            _muxer?.Dispose();
+            if (!_muxerIsShared)
+            {
+                _muxer?.Dispose();
+            }
+
+            _muxer = null!;
+            _db = null!;
+            _muxerIsShared = false;
         }
 
         private enum UpsertResult

--- a/src/Redis/Orleans.GrainDirectory.Redis/Hosting/RedisGrainDirectoryProviderBuilder.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Hosting/RedisGrainDirectoryProviderBuilder.cs
@@ -27,7 +27,7 @@ internal sealed class RedisGrainDirectoryProviderBuilder : IProviderBuilder<ISil
                 {
                     // Get a connection multiplexer instance by name.
                     var multiplexer = services.GetRequiredKeyedService<IConnectionMultiplexer>(serviceKey);
-                    options.CreateMultiplexer = _ => Task.FromResult(multiplexer);
+                    options.CreateMultiplexer = _ => Task.FromResult((Multiplexer: multiplexer, IsShared: true));
                     options.ConfigurationOptions = new ConfigurationOptions();
                 }
                 else

--- a/src/Redis/Orleans.GrainDirectory.Redis/Options/RedisGrainDirectoryOptions.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Options/RedisGrainDirectoryOptions.cs
@@ -18,9 +18,12 @@ namespace Orleans.Configuration
         public ConfigurationOptions ConfigurationOptions { get; set; }
 
         /// <summary>
-        /// The delegate used to create a Redis connection multiplexer.
+        /// The delegate used to create a Redis connection multiplexer and indicate whether it is shared.
         /// </summary>
-        public Func<RedisGrainDirectoryOptions, Task<IConnectionMultiplexer>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
+        /// <remarks>
+        /// When <c>IsShared</c> is <see langword="true"/>, the provider will not dispose the returned multiplexer.
+        /// </remarks>
+        public Func<RedisGrainDirectoryOptions, Task<(IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
 
         /// <summary>
         /// Entry expiry, null by default. A value should be set ONLY for ephemeral environments (like in tests).
@@ -31,7 +34,8 @@ namespace Orleans.Configuration
         /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
-        public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisGrainDirectoryOptions options) => await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions);
+        public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisGrainDirectoryOptions options)
+            => (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions), IsShared: false);
     }
 
     internal class RedactRedisConfigurationOptions : RedactAttribute

--- a/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
@@ -26,6 +26,7 @@ namespace Orleans.GrainDirectory.Redis
         // Both are initialized in the Initialize method.
         private IConnectionMultiplexer _redis = null!;
         private IDatabase _database = null!;
+        private bool _redisIsShared;
 
         private bool _disposed;
 
@@ -178,7 +179,7 @@ namespace Orleans.GrainDirectory.Redis
 
         public async Task Initialize(CancellationToken ct = default)
         {
-            _redis = await _directoryOptions.CreateMultiplexer(_directoryOptions);
+            (_redis, _redisIsShared) = await _directoryOptions.CreateMultiplexer(_directoryOptions);
 
             // Configure logging
             _redis.ConnectionRestored += LogConnectionRestored;
@@ -197,17 +198,21 @@ namespace Orleans.GrainDirectory.Redis
 
                 try
                 {
-                    await _redis.DisposeAsync();
-                }
-                finally
-                {
                     _redis.ConnectionRestored -= LogConnectionRestored;
                     _redis.ConnectionFailed -= LogConnectionFailed;
                     _redis.ErrorMessage -= LogErrorMessage;
                     _redis.InternalError -= LogInternalError;
 
+                    if (!_redisIsShared)
+                    {
+                        await _redis.DisposeAsync();
+                    }
+                }
+                finally
+                {
                     _redis = null!;
                     _database = null!;
+                    _redisIsShared = false;
                 }
             }
         }

--- a/src/Redis/Orleans.Persistence.Redis/Hosting/RedisGrainStorageProviderBuilder.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Hosting/RedisGrainStorageProviderBuilder.cs
@@ -28,7 +28,7 @@ internal sealed class RedisGrainStorageProviderBuilder : IProviderBuilder<ISiloB
                 {
                     // Get a connection multiplexer instance by name.
                     var multiplexer = services.GetRequiredKeyedService<IConnectionMultiplexer>(serviceKey);
-                    options.CreateMultiplexer = _ => Task.FromResult(multiplexer);
+                    options.CreateMultiplexer = _ => Task.FromResult((Multiplexer: multiplexer, IsShared: true));
                     options.ConfigurationOptions = new ConfigurationOptions();
                 }
                 else

--- a/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
@@ -35,9 +35,12 @@ namespace Orleans.Persistence
         public ConfigurationOptions? ConfigurationOptions { get; set; }
 
         /// <summary>
-        /// The delegate used to create a Redis connection multiplexer.
+        /// The delegate used to create a Redis connection multiplexer and indicate whether it is shared.
         /// </summary>
-        public Func<RedisStorageOptions, Task<IConnectionMultiplexer>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
+        /// <remarks>
+        /// When <c>IsShared</c> is <see langword="true"/>, the provider will not dispose the returned multiplexer.
+        /// </remarks>
+        public Func<RedisStorageOptions, Task<(IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
 
         /// <summary>
         /// Entry expiry, null by default. A value should be set only for ephemeral environments, such as testing environments.
@@ -53,7 +56,8 @@ namespace Orleans.Persistence
         /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
-        public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisStorageOptions options) => await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!);
+        public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisStorageOptions options)
+            => (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!), IsShared: false);
     }
 
     /// <summary>

--- a/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
@@ -33,6 +33,7 @@ namespace Orleans.Persistence
         private readonly Func<string, GrainId, RedisKey> _getKeyFunc;
         private IConnectionMultiplexer _connection;
         private IDatabase _db;
+        private bool _connectionIsShared;
 
         /// <summary>
         /// Creates a new instance of the <see cref="RedisGrainStorage"/> type.
@@ -71,7 +72,7 @@ namespace Orleans.Persistence
             {
                 LogDebugInitializing(_name, _serviceId, _options.DeleteStateOnClear);
 
-                _connection = await _options.CreateMultiplexer(_options).ConfigureAwait(false);
+                (_connection, _connectionIsShared) = await _options.CreateMultiplexer(_options).ConfigureAwait(false);
                 _db = _connection.GetDatabase();
 
                 var elapsed = Stopwatch.GetElapsedTime(startTime);
@@ -255,8 +256,20 @@ namespace Orleans.Persistence
         {
             if (_connection is null) return;
 
-            await _connection.CloseAsync().ConfigureAwait(false);
-            _connection.Dispose();
+            try
+            {
+                 if (!_connectionIsShared)
+                {
+                    await _connection.CloseAsync().ConfigureAwait(false);
+                    _connection.Dispose();
+                }
+            }
+            finally
+            {
+                _connection = null;
+                _db = null;
+                _connectionIsShared = false;
+            }
         }
 
         private T CreateInstance<T>() => _activatorProvider.GetActivator<T>().Create();

--- a/src/Redis/Orleans.Reminders.Redis/Hosting/RedisRemindersProviderBuilder.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Hosting/RedisRemindersProviderBuilder.cs
@@ -26,7 +26,7 @@ internal sealed class RedisRemindersProviderBuilder : IProviderBuilder<ISiloBuil
                 {
                     // Get a connection multiplexer instance by name.
                     var multiplexer = services.GetRequiredKeyedService<IConnectionMultiplexer>(serviceKey);
-                    options.CreateMultiplexer = _ => Task.FromResult(multiplexer);
+                    options.CreateMultiplexer = _ => Task.FromResult((Multiplexer: multiplexer, IsShared: true));
                     options.ConfigurationOptions = new ConfigurationOptions();
                 }
                 else

--- a/src/Redis/Orleans.Reminders.Redis/Providers/RedisReminderTableOptions.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Providers/RedisReminderTableOptions.cs
@@ -19,9 +19,12 @@ namespace Orleans.Configuration
         public ConfigurationOptions ConfigurationOptions { get; set; }
 
         /// <summary>
-        /// The delegate used to create a Redis connection multiplexer.
+        /// The delegate used to create a Redis connection multiplexer and indicate whether it is shared.
         /// </summary>
-        public Func<RedisReminderTableOptions, Task<IConnectionMultiplexer>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
+        /// <remarks>
+        /// When <c>IsShared</c> is <see langword="true"/>, the provider will not dispose the returned multiplexer.
+        /// </remarks>
+        public Func<RedisReminderTableOptions, Task<(IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
 
         /// <summary>
         /// Entry expiry, null by default. A value should be set ONLY for ephemeral environments (like in tests).
@@ -32,7 +35,8 @@ namespace Orleans.Configuration
         /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
-        public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisReminderTableOptions options) => await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions);
+        public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisReminderTableOptions options)
+            => (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions), IsShared: false);
     }
 
     internal class RedactRedisConfigurationOptions : RedactAttribute

--- a/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
@@ -18,7 +18,7 @@ using static System.FormattableString;
 
 namespace Orleans.Reminders.Redis
 {
-    internal partial class RedisReminderTable : IReminderTable
+    internal partial class RedisReminderTable : IReminderTable, IDisposable
     {
         private readonly RedisKey _hashSetKey;
         private readonly RedisReminderTableOptions _redisOptions;
@@ -26,6 +26,7 @@ namespace Orleans.Reminders.Redis
         private readonly ILogger _logger;
         private IConnectionMultiplexer _muxer;
         private IDatabase _db;
+        private bool _muxerIsShared;
 
         private readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings()
         {
@@ -51,7 +52,7 @@ namespace Orleans.Reminders.Redis
         {
             try
             {
-                _muxer = await _redisOptions.CreateMultiplexer(_redisOptions);
+                (_muxer, _muxerIsShared) = await _redisOptions.CreateMultiplexer(_redisOptions);
                 _db = _muxer.GetDatabase();
 
                 if (_redisOptions.EntryExpiry is { } expiry)
@@ -186,6 +187,18 @@ namespace Orleans.Reminders.Redis
             {
                 throw new RedisRemindersException(Invariant($"{exception.GetType()}: {exception.Message}"));
             }
+        }
+
+        public void Dispose()
+        {
+            if (!_muxerIsShared)
+            {
+                _muxer?.Dispose();
+            }
+
+            _muxer = null;
+            _db = null;
+            _muxerIsShared = false;
         }
 
         private static ReminderEntry ConvertToEntry(string reminderValue)

--- a/src/api/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.cs
+++ b/src/api/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.cs
@@ -41,13 +41,13 @@ namespace Orleans.Clustering.Redis
     {
         public StackExchange.Redis.ConfigurationOptions ConfigurationOptions { get { throw null; } set { } }
 
-        public System.Func<RedisClusteringOptions, System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer>> CreateMultiplexer { get { throw null; } set { } }
+        public System.Func<RedisClusteringOptions, System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get { throw null; } set { } }
 
         public System.Func<Configuration.ClusterOptions, StackExchange.Redis.RedisKey> CreateRedisKey { get { throw null; } set { } }
 
         public System.TimeSpan? EntryExpiry { get { throw null; } set { } }
 
-        public static System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer> DefaultCreateMultiplexer(RedisClusteringOptions options) { throw null; }
+        public static System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisClusteringOptions options) { throw null; }
 
         public static StackExchange.Redis.RedisKey DefaultCreateRedisKey(Configuration.ClusterOptions clusterOptions) { throw null; }
     }

--- a/src/api/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.cs
+++ b/src/api/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.cs
@@ -12,11 +12,11 @@ namespace Orleans.Configuration
     {
         public StackExchange.Redis.ConfigurationOptions ConfigurationOptions { get { throw null; } set { } }
 
-        public System.Func<RedisGrainDirectoryOptions, System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer>> CreateMultiplexer { get { throw null; } set { } }
+        public System.Func<RedisGrainDirectoryOptions, System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get { throw null; } set { } }
 
         public System.TimeSpan? EntryExpiry { get { throw null; } set { } }
 
-        public static System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer> DefaultCreateMultiplexer(RedisGrainDirectoryOptions options) { throw null; }
+        public static System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisGrainDirectoryOptions options) { throw null; }
     }
 
     public partial class RedisGrainDirectoryOptionsValidator : IConfigurationValidator

--- a/src/api/Redis/Orleans.Persistence.Redis/Orleans.Persistence.Redis.cs
+++ b/src/api/Redis/Orleans.Persistence.Redis/Orleans.Persistence.Redis.cs
@@ -59,7 +59,7 @@ namespace Orleans.Persistence
     {
         public StackExchange.Redis.ConfigurationOptions? ConfigurationOptions { get { throw null; } set { } }
 
-        public System.Func<RedisStorageOptions, System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer>> CreateMultiplexer { get { throw null; } set { } }
+        public System.Func<RedisStorageOptions, System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get { throw null; } set { } }
 
         public bool DeleteStateOnClear { get { throw null; } set { } }
 
@@ -71,7 +71,7 @@ namespace Orleans.Persistence
 
         public int InitStage { get { throw null; } set { } }
 
-        public static System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer> DefaultCreateMultiplexer(RedisStorageOptions options) { throw null; }
+        public static System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisStorageOptions options) { throw null; }
     }
 
     public static partial class RedisStorageOptionsExtensions

--- a/src/api/Redis/Orleans.Reminders.Redis/Orleans.Reminders.Redis.cs
+++ b/src/api/Redis/Orleans.Reminders.Redis/Orleans.Reminders.Redis.cs
@@ -12,11 +12,11 @@ namespace Orleans.Configuration
     {
         public StackExchange.Redis.ConfigurationOptions ConfigurationOptions { get { throw null; } set { } }
 
-        public System.Func<RedisReminderTableOptions, System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer>> CreateMultiplexer { get { throw null; } set { } }
+        public System.Func<RedisReminderTableOptions, System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get { throw null; } set { } }
 
         public System.TimeSpan? EntryExpiry { get { throw null; } set { } }
 
-        public static System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer> DefaultCreateMultiplexer(RedisReminderTableOptions options) { throw null; }
+        public static System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisReminderTableOptions options) { throw null; }
     }
 
     public partial class RedisReminderTableOptionsValidator : IConfigurationValidator


### PR DESCRIPTION
Follow-up for dotnet/orleans#9940 based on review feedback.

Updates Redis providers to distinguish owned Redis multiplexers from shared DI-provided multiplexers:

- Change Redis `CreateMultiplexer` delegates to return `(Multiplexer, IsShared)`.
- Mark `ServiceKey`-resolved multiplexers as shared.
- Skip `CloseAsync`/`Dispose` for shared multiplexers while still cleaning up provider references and grain-directory event handlers.
- Update Redis API snapshots.

Validation:

- `dotnet build test\Extensions\Orleans.Redis.Tests\Orleans.Redis.Tests.csproj --no-restore --tl:off --verbosity:minimal`
